### PR TITLE
Update label prompt

### DIFF
--- a/notebooks/Annotation and Continual Learning Overview.ipynb
+++ b/notebooks/Annotation and Continual Learning Overview.ipynb
@@ -543,7 +543,7 @@
     "bundle_params = {\n",
     "    \"points\": [[20,20,20], [20, 40, 60]],\n",
     "    \"point_labels\": [2, 2],\n",
-    "    \"label_prompt\": [2],\n",
+    "    \"label_prompt\": [3],\n",
     "}\n",
     "\n",
     "data = {\n",


### PR DESCRIPTION
Since vista3d 0.3.4, when providing label_prompt to 2/20/21, points cannot be provided at the same time (these three labels have subclasses), therefore, this PR is used to update the default prompt example to avoid error.

The above rule is verified by vista3d author, and he will update the readme in the next version