### PR TITLE
Rename genai to maisi (#130)

### DIFF
--- a/notebooks/Medical Image Generation with MAISI.ipynb
+++ b/notebooks/Medical Image Generation with MAISI.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "- Introduction\n",
     "- Setup\n",
-    "- Generative AI Experiment Creation\n",
+    "- MAISI Experiment Creation\n",
     "- Generating Medical Image\n",
     "- Download the Job Log\n",
     "- Download the Generated Medical Images\n",
@@ -33,7 +33,7 @@
     "\n",
     "### What You Can Expect to Learn\n",
     "\n",
-    "In the end of this guide, you will be able to generate synthetic CT scans using generative AI models on the NVIDIA DGX Cloud. These synthetic CT scans can be used for a variety of applications, including medical imaging research, algorithm development, education, and training.\n",
+    "In the end of this guide, you will be able to generate synthetic CT scans using the MAISI model on the NVIDIA DGX Cloud. These synthetic CT scans can be used for a variety of applications, including medical imaging research, algorithm development, education, and training.\n",
     "\n",
     "![image.png](./end2end_pic/maisi.png)\n",
     "\n",
@@ -44,9 +44,9 @@
     "- Simulation and testing: Synthetic CT scans can be used for simulating different clinical scenarios, testing algorithms, and evaluating the performance of medical imaging systems.\n",
     "- Education and training: Synthetic CT scans provide a valuable resource for medical education and training, allowing students and healthcare professionals to practice interpreting and analyzing scans.\n",
     "\n",
-    "To get started, make sure you have generated your credentials by following the step-by-step guide on [Generating and Managing Your Credentials](./Generating%20and%20Managing%20Your%20Credentials.ipynb). These credentials will be required for accessing the NVIDIA DGX Cloud and running the generative AI experiments.\n",
+    "To get started, make sure you have generated your credentials by following the step-by-step guide on [Generating and Managing Your Credentials](./Generating%20and%20Managing%20Your%20Credentials.ipynb). These credentials will be required for accessing the NVIDIA DGX Cloud and running the MAISI experiments.\n",
     "\n",
-    "In this guide, we will explore the process of synthetic medical image generation using generative AI, specifically focusing on CT scans. We will cover the setup, training of generative AI models, and the generation of synthetic CT scans using NVIDIA DGX Cloud.\n",
+    "In this guide, we will explore the process of synthetic medical image generation using MAISI, specifically focusing on CT scans. We will cover the setup and the generation of synthetic CT scans using NVIDIA DGX Cloud.\n",
     "\n",
     "Let's embark on this exciting journey of synthetic medical image generation and unlock new possibilities in medical imaging research and applications!"
    ]
@@ -151,14 +151,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generative AI Experiment Creation\n"
+    "## MAISI Experiment Creation\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Find the base experiment for Generative AI"
+    "#### Find the base experiment for MAISI"
    ]
   },
   {
@@ -172,8 +172,8 @@
     "assert response.status_code == 200, f\"List base experiments failed, got {response.text}.\"\n",
     "res = response.json()\n",
     "\n",
-    "gen_ai_base_exps = [p for p in res[\"experiments\"] if p[\"network_arch\"] == \"monai_genai\" and p[\"name\"] == \"MONAI GenerativeAI\"]\n",
-    "assert len(gen_ai_base_exps) > 0, \"No base experiment found for Generative AI\"\n",
+    "gen_ai_base_exps = [p for p in res[\"experiments\"] if p[\"network_arch\"] == \"monai_maisi\" and p[\"name\"] == \"MONAI MAISI\"]\n",
+    "assert len(gen_ai_base_exps) > 0, \"No base experiment found for MAISI\"\n",
     "print(\"List of available base experiments for MAISI:\")\n",
     "for exp in gen_ai_base_exps:\n",
     "    print(f\"  {exp['id']}: {exp['name']} v{exp['version']}\")\n",
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Create Generative AI Experiment"
+    "#### Create MAISI Experiment"
    ]
   },
   {
@@ -210,11 +210,11 @@
     "}\n",
     "\n",
     "data = {\n",
-    "    \"name\": \"generative_ai_experiment\",\n",
-    "    \"description\": \"MONAI Generative AI Experiment\",\n",
+    "    \"name\": \"maisi_experiment\",\n",
+    "    \"description\": \"MONAI MAISI experiment\",\n",
     "    \"type\": \"medical\",\n",
     "    \"base_experiment\": [base_exp_maisi],\n",
-    "    \"network_arch\": \"monai_genai\",\n",
+    "    \"network_arch\": \"monai_maisi\",\n",
     "    \"cloud_details\": experiment_cloud_details,\n",
     "}\n",
     "\n",
@@ -256,7 +256,7 @@
     "    \"action\": \"generate\",\n",
     "    \"specs\": {\n",
     "        \"num_output_samples\": 1,                    # Number of output samples\n",
-    "        \"body_region\": [\"chest\"],                   # Body region (“please refer to the list above for the supported nody regions)\n",
+    "        \"body_region\": [\"chest\"],                   # Body region (please refer to the list above for the supported body regions)\n",
     "        \"organ_list\": [\"liver\"],                    # Organs (please refer to the list above for the supported organs)\n",
     "    },\n",
     "}\n",
@@ -371,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "folder = f\"shared/orgs/{ngc_org}/users/{user_id}/jobs/{job_id}/generative_ai_v{version}/output\"\n",
+    "folder = f\"shared/orgs/{ngc_org}/users/{user_id}/jobs/{job_id}/maisi_v{version}/output\"\n",
     "\n",
     "if cloud_type == \"aws\":\n",
     "    cs_driver = get_driver(Provider.S3)\n",
@@ -464,11 +464,11 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "In this project, we explored the potential of Generative AI in the field of medical imaging. We implemented a generative model that can create new, synthetic medical images. This has vast implications for medical research and training, as it allows for the generation of large datasets without the need for patient involvement or the associated privacy concerns.\n",
+    "In this project, we explored the potential of MAISI in the field of medical imaging. We implemented a generative model that can create new, synthetic medical images. This has vast implications for medical research and training, as it allows for the generation of large datasets without the need for patient involvement or the associated privacy concerns.\n",
     "\n",
     "However, it's important to note that while the results are promising, the technology is not without its limitations and ethical considerations. The quality of the generated images is highly dependent on the quality and diversity of the training data. Additionally, care must be taken to ensure that the synthetic images do not misrepresent or oversimplify complex medical conditions.\n",
     "\n",
-    "In conclusion, Generative AI holds great promise in the field of medical imaging, offering a powerful tool for research, training, and potentially even diagnosis and treatment planning. However, as with any powerful tool, it must be used responsibly and ethically.\n",
+    "In conclusion, MAISI holds great promise in the field of medical imaging, offering a powerful tool for research, training, and potentially even diagnosis and treatment planning. However, as with any powerful tool, it must be used responsibly and ethically.\n",
     "\n"
    ]
   }

--- a/notebooks/Medical Image Generation with MAISI.ipynb
+++ b/notebooks/Medical Image Generation with MAISI.ipynb
@@ -172,7 +172,7 @@
     "assert response.status_code == 200, f\"List base experiments failed, got {response.text}.\"\n",
     "res = response.json()\n",
     "\n",
-    "gen_ai_base_exps = [p for p in res[\"experiments\"] if p[\"network_arch\"] == \"monai_maisi\" and p[\"name\"] == \"MONAI MAISI\"]\n",
+    "gen_ai_base_exps = [p for p in res[\"experiments\"] if p[\"network_arch\"] == \"monai_maisi\"]\n",
     "assert len(gen_ai_base_exps) > 0, \"No base experiment found for MAISI\"\n",
     "print(\"List of available base experiments for MAISI:\")\n",
     "for exp in gen_ai_base_exps:\n",
@@ -489,7 +489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.1.-1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Change a couple of places that uses `genai` to `maisi`.

For examples:
- `monai_genai` -> `monai_maisi` (network_arch)
- GenAI -> MAISI